### PR TITLE
set max-width & padding for brandimage

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -33,12 +33,13 @@ vertical-align: baseline;;
 }
 
 .navbar-brand-img {
-padding: 0;
+    padding: 0px;
 }
 @media screen and (max-width: 768px) {
     a.navbar-brand-img>img {
       vertical-align: bottom;
-      padding-left: 20px;
+      padding: 1em 0 0 15px;
+      max-width: 80%;
     }
 }
 


### PR DESCRIPTION
Restrict header image width to 80% on mobile.

Before
![screenshot_20170605_081316](https://cloud.githubusercontent.com/assets/516267/26769287/4eb21d70-49cb-11e7-931b-089f134c081e.png)

After
![screenshot_20170605_084111](https://cloud.githubusercontent.com/assets/516267/26769295/5910f728-49cb-11e7-8afd-367693510529.png)
