### PR TITLE
Hiding index page for posts in the sidebar

### DIFF
--- a/layouts/partials/bloc/content/sidebar.html
+++ b/layouts/partials/bloc/content/sidebar.html
@@ -10,7 +10,7 @@
       <header><div class="title"><b>{{ i18n "latestposts" }}</b></div></header>
       <div class="content">
         <ul>
-        {{ range first 10 (where .Site.Pages "Type" "post") }}
+        {{ range first 10 (where .Data.Pages "Type" "post") }}
           <li>
           <a href="{{ .Permalink }}">{{ .Title }}</a>
           </li>


### PR DESCRIPTION
via .Site.Pages also the section index page is displayed in the sidebar
if there are less then 9 posts