### PR TITLE
Discover the sidebar post list via site pages

### DIFF
--- a/layouts/partials/bloc/content/sidebar.html
+++ b/layouts/partials/bloc/content/sidebar.html
@@ -10,7 +10,7 @@
       <header><div class="title"><b>{{ i18n "latestposts" }}</b></div></header>
       <div class="content">
         <ul>
-        {{ range first 10 (where .Data.Pages "Type" "post") }}
+        {{ range first 10 (where (where .Site.Pages "Type" "post") "IsPage" true) }}
           <li>
           <a href="{{ .Permalink }}">{{ .Title }}</a>
           </li>


### PR DESCRIPTION
.Data.Pages might miss results if used in the blog post itself.
So lets use Site.Pages again for discovery, but filter only for real pages with content