### PR TITLE
Avoid data schema if googleplus account is not defined

### DIFF
--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -46,6 +46,7 @@
 <meta name="twitter:domain" content="{{ .Site.BaseURL }}">
   {{ end }}
 
+  {{ if ne .Site.Params.googleplus "" }}
 <script type="application/ld+json">
   {
     "@context": "http://schema.org",
@@ -60,6 +61,7 @@
     "wordCount": {{ .WordCount }}
   }
 </script>
+  {{ end }}
 {{ end }}
 
 {{ if .RSSLink }}


### PR DESCRIPTION
Looking at schema.org I'm not completely sure if this makes sense, maybe its better to allow configuration of URL?