### PR TITLE
Let comments be in the same weight as content

### DIFF
--- a/layouts/partials/bloc/content/comments.html
+++ b/layouts/partials/bloc/content/comments.html
@@ -1,3 +1,3 @@
-<div class="col-xs-12 col-sm-12 col-md-9 col-lg-9">
+<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
   {{ partial "modules/disqus.html" . }}
 </div>


### PR DESCRIPTION
you can also see this problem live on some of your web sites, e.g. : https://blog.appernetic.io/2016/07/14/use-live-chat-to-beat-the-competition/

**Before:**

![before](https://user-images.githubusercontent.com/1645670/26990296-6fdd590e-4d56-11e7-8bd2-b187abb6ad8f.png)

**After:**

![after](https://user-images.githubusercontent.com/1645670/26990306-763f77c8-4d56-11e7-96af-9467700bc1dd.png)


