### PR TITLE
Removal of disqus comments count code

### DIFF
--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -13,27 +13,6 @@
 {{ end }}
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular.min.js"></script>
 <script src="/js/popover/angular-storage.min.js"></script>
-
-{{ with .Site.DisqusShortname }}
-<script type="text/javascript">
-  (function() {
-    // Don't ever inject Disqus on localhost--it creates unwanted
-    // discussions from 'localhost:1313' on your Disqus account...
-    if (window.location.hostname == "localhost")
-      return;
-
-    var dsq = document.createElement('script'); dsq.async = true; dsq.type = 'text/javascript';
-    dsq.src = '//{{ . }}.disqus.com/count.js';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-  })();
-  $('#return-to-top').click(function() {      // When arrow is clicked
-    $('body,html').animate({
-        scrollTop : 0                       // Scroll to top of body
-    }, 500);
-});
-</script>
-{{ end }}
-
 <script src="{{ "js/highlight.pack.js" | absURL }}"></script>
 <script src="{{ "js/site.js" | absURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
its used to show the comment count in the listings,
it looks like its not used anythere in this theme,
so lets avoid additional browser request without any reason