### PR TITLE
Fix the generated URLs

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
   {{ $data := .Data }}
   {{ range $key,$value := .Data.Terms.ByCount }}
     <li>
-      <a href="{{ $baseurl }}{{ $data.Plural }}/{{ $value.Name | urlize }}">
+      <a href="{{ $data.Plural | relLangURL }}/{{ $value.Name | urlize }}">
         {{ $value.Name }}
       </a>
       <strong>


### PR DESCRIPTION
if baseURL is configured without the trailing slash, otherwise it looks like
www.example.comtags/tagname