### PR TITLE
Support for _index.md content pages

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -3,6 +3,7 @@
   <header>
     {{ partial "bloc/content/h1-title.html" . }}
   </header>
+  {{ .Content }}
   {{ range $index, $foo := .Paginator.Pages  }}
     {{ .Render "section.li" }}
   {{ end }}


### PR DESCRIPTION
If there's an _index.md, then the content is pulled in.

See - https://bwaycer.github.io/hugo_tutorial.hugo/content/using-index-md/