### PR TITLE
Remove bundle integrity checks - Fix site rendering when served from other domains

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -3,6 +3,7 @@
   <header>
     {{ partial "bloc/content/h1-title.html" . }}
   </header>
+  {{ .Content }}
   {{ range $index, $foo := .Paginator.Pages  }}
     {{ .Render "section.li" }}
   {{ end }}

--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -26,4 +26,4 @@
 {{ end }}
 
 {{ $css := .Scratch.Get "css" | resources.Concat "css/bundle.css" | resources.Minify| resources.Fingerprint "sha512" }}
-<link rel="stylesheet" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}">
+<link rel="stylesheet" href="{{ $css.Permalink }}" >

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -62,7 +62,7 @@ CONTENTLANGUAGE = {{ .Site.Params.DefaultContentLanguage }}; // used in pathname
 {{ end }}
 
 {{ $js := .Scratch.Get "js" | resources.Concat "js/bundle.js" | resources.Minify| resources.Fingerprint "sha512" }}
-<script  src="{{$js.Permalink}}" integrity="{{ $js.Data.Integrity }}"></script>
+<script  src="{{$js.Permalink}}" ></script>
 
 
 {{ if ne .Site.Params.mathjax "" }}


### PR DESCRIPTION
if you serve the blog from multiple domains, then js/css integrity checks fail resulting in the client not actually processing script/css. This PR removes the checks.
