### PR TITLE
add meta property pointing to source content file

### DIFF
--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -17,10 +17,10 @@
 <meta property="og:site_name" content="{{ .Site.Title }}"/>
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="{{ .Site.LanguageCode }}">
-
 {{ if not .IsPage }}
 <meta property="og:type" content="website" />
 {{ else }}
+<meta property="content-source" content="{{ .File.Path}}">
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ .Description }}"/>
 <meta property="og:article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}" />


### PR DESCRIPTION
Add meta property with the source content file path. Makes it easy to map to the source file when you come back to edit after a few months.